### PR TITLE
Add collapsable solution block

### DIFF
--- a/assets/panels.css
+++ b/assets/panels.css
@@ -74,10 +74,9 @@
 }
 
 .panel-heading h3 span {
+  float: right;
+  margin-top: 0.5em;
   font-size: 0.7em;
-  position: absolute;
-  bottom: 0;
-  right: 0;
 }
 
 .panel-body {

--- a/assets/panels.css
+++ b/assets/panels.css
@@ -75,7 +75,7 @@
 
 .panel-heading h3 span {
   float: right;
-  margin-top: 0.5em;
+  margin-top: 0.3em;
   font-size: 0.7em;
 }
 

--- a/assets/panels.css
+++ b/assets/panels.css
@@ -70,8 +70,17 @@
   font-size: 1em;
   margin: 0;
   padding: 0;
+  position: relative;
+}
+
+.panel-heading h3 span {
+  font-size: 0.7em;
+  position: absolute;
+  bottom: 0;
+  right: 0;
 }
 
 .panel-body {
   padding: 15px;
+  display: block;
 }

--- a/assets/panels.js
+++ b/assets/panels.js
@@ -1,7 +1,7 @@
 function toggle(id) {
   var ele = document.getElementById("panel-"+id);
   var text = document.getElementById("heading-"+id);
-  if(ele.style.display == "block") {
+  if(window.getComputedStyle(ele).display == "block") {
     ele.style.display = "none";
     text.innerHTML = "Click to expand";
   }

--- a/assets/panels.js
+++ b/assets/panels.js
@@ -1,9 +1,12 @@
 function toggle(id) {
   var ele = document.getElementById("panel-"+id);
+  var text = document.getElementById("heading-"+id);
   if(ele.style.display == "block") {
     ele.style.display = "none";
+    text.innerHTML = "Click to expand";
   }
   else {
     ele.style.display = "block";
+    text.innerHTML = "";
   }
 }

--- a/assets/panels.js
+++ b/assets/panels.js
@@ -1,0 +1,9 @@
+function toggle(id) {
+  var ele = document.getElementById("panel-"+id);
+  if(ele.style.display == "block") {
+    ele.style.display = "none";
+  }
+  else {
+    ele.style.display = "block";
+  }
+}

--- a/index.js
+++ b/index.js
@@ -19,20 +19,35 @@ function parseMarkdown(text, debug) {
 
 /* `icon` is the name of a Font Awesome icon class. */
 function panel(block, type, icon) {
+  // Generate a random id so blocks can be collapsed
+  var id = Math.floor(Math.random()*10000000000);
+
   var s  = '<div class="panel panel-' + type + '">';
   if (block.args.length > 0) {
     s += '<div class="panel-heading">';
-    s += '<h3 class="panel-title">';
+    s += '<h3 class="panel-title" onclick="javascript:toggle('+id+');">';
     if (icon !== undefined) {
       s += '<i class="fa fa-' + icon + '">';
       s += "</i> ";
     }
     s += block.args[0];
+    if (block.name == "solution") {
+      s +=  '<span>Click to expand</span>';
+    }
     s += "</h3>";
     s += "</div>";
   }
-  s += '<div class="panel-body">';
+  if (block.name == "solution") {
+    s += '<div class="panel-body" style="display: none" id="panel-'+id+'">';
+  } else {
+    s += '<div class="panel-body" id="panel-'+id+'">';
+  }
   s += parseMarkdown(block.body);
+  if (block.blocks) {
+    block.blocks.forEach((subblock) => {
+      s += panel(subblock, "danger", "line-chart");
+    });
+  }
   s += "</div>";
   s += "</div>";
   return s;
@@ -42,7 +57,10 @@ module.exports = {
   website: {
     assets: "./assets",
     css: [
-      "panels.css"
+      "panels.css",
+    ],
+    js: [
+      "panels.js",
     ]
   },
 
@@ -85,9 +103,14 @@ module.exports = {
       }
     },
     challenge: {
+      blocks: ['solution'],
       process: function(block) {
-        parseMarkdown(block.body, true);
-        return panel(block, "success", "check-square-o");
+        return panel(block, "success", "square-o");
+      }
+    },
+    solution: {
+      process: function(block) {
+        return panel(block, "danger", "check-square-o");
       }
     },
     objectives: {

--- a/index.js
+++ b/index.js
@@ -31,9 +31,11 @@ function panel(block, type, icon) {
       s += "</i> ";
     }
     s += block.args[0];
+    s +=  '<span id="heading-'+id+'">'
     if (block.name == "solution") {
-      s +=  '<span>Click to expand</span>';
+      s += 'Click to expand'
     }
+    s += '</span>';
     s += "</h3>";
     s += "</div>";
   }

--- a/index.js
+++ b/index.js
@@ -119,6 +119,11 @@ module.exports = {
       process: function(block) {
         return panel(block, "warning", "line-chart");
       }
+    },
+    keypoints: {
+      process: function(block) {
+        return panel(block, "success", "key");
+      }
     }
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitbook-plugin-panels",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Block definitions for Bootstrap panels.",
   "dependencies": {
     "marked": "^0.3.6"


### PR DESCRIPTION
Example:
<img width="774" alt="screen shot 2017-10-18 at 19 54 52" src="https://user-images.githubusercontent.com/5220533/31734205-445052ce-b43e-11e7-85a5-236d60e8c53a.png">

I'm not happy with the formatting of the "Click here to expand" text, suggestions welcome.