### PR TITLE
Adding ability to put code in title

### DIFF
--- a/assets/ebook.css
+++ b/assets/ebook.css
@@ -36,6 +36,10 @@
     background-color: rgba(247, 247, 247, 0.55);
 }
 
+.panel-default .panel-heading .panel-title code {
+    background-color: rgb(237, 237, 237);
+}
+
 .panel-default > .panel-heading {
   color: #333;
   background-color: #f5f5f5;

--- a/assets/ebook.css
+++ b/assets/ebook.css
@@ -32,6 +32,10 @@
   border-top-right-radius: 3px;
 }
 
+.panel-heading .panel-title code {
+    background-color: rgba(247, 247, 247, 0.55);
+}
+
 .panel-default > .panel-heading {
   color: #333;
   background-color: #f5f5f5;

--- a/assets/panels.css
+++ b/assets/panels.css
@@ -31,6 +31,10 @@
   border-top-right-radius: 3px;
 }
 
+.panel-heading .panel-title code {
+    background-color: rgba(247, 247, 247, 0.55);
+}
+
 .panel-default > .panel-heading {
   color: #333;
   background-color: #f5f5f5;

--- a/assets/panels.css
+++ b/assets/panels.css
@@ -35,6 +35,10 @@
     background-color: rgba(247, 247, 247, 0.55);
 }
 
+.panel-default .panel-heading .panel-title code {
+    background-color: rgb(237, 237, 237);
+}
+
 .panel-default > .panel-heading {
   color: #333;
   background-color: #f5f5f5;

--- a/index.js
+++ b/index.js
@@ -1,13 +1,15 @@
 var marked = require('marked');
-// var output = require('lib/output');
 
-function parseMarkdown(text, debug) {
+function parseMarkdown(text, inline=false) {
   const latexMatcher = /(\$\$[\s\S][^$]+\$\$)/g;
   const latexPlaceholder = 'LATEXPLACEHOLDER';
   const matches = text.match(latexMatcher);
   const textWithoutLatex = text.replace(latexMatcher, latexPlaceholder);
 
-  var str = marked(textWithoutLatex);
+  if(inline) {
+      var str = marked.inlineLexer(textWithoutLatex, []);
+  } else
+      var str = marked(textWithoutLatex);
 
   if (matches !== null) {
     for (var i = 0; i < matches.length; i++) {
@@ -32,7 +34,7 @@ function panel(output_type, block, type, icon, hide=false) {
       s += '<i class="fa fa-' + icon + '">';
       s += "</i> ";
     }
-    s += block.args[0];
+    s += parseMarkdown(block.args[0], true);
     s +=  '<span id="heading-'+id+'">'
     if (start_closed) {
       s += 'Click to expand'

--- a/index.js
+++ b/index.js
@@ -6,10 +6,11 @@ function parseMarkdown(text, inline=false) {
   const matches = text.match(latexMatcher);
   const textWithoutLatex = text.replace(latexMatcher, latexPlaceholder);
 
-  if(inline) {
+  if (inline) {
       var str = marked.inlineLexer(textWithoutLatex, []);
-  } else
+  } else {
       var str = marked(textWithoutLatex);
+  }
 
   if (matches !== null) {
     for (var i = 0; i < matches.length; i++) {


### PR DESCRIPTION
This allows you to use markdown, like single tick marks, in the title of a block. The code highlight blends into the surrounding block. (Might need a custom color for `panel-default`, though)

It still does not allow math in titles, though. That's probably not as needed as preformatted code. 