### PR TITLE
Add challenge block type that is hidden by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,6 +109,12 @@ module.exports = {
         return panel(this.output.name, block, "success", "square-o");
       }
     },
+    hiddenchallenge: {
+      blocks: ['solution'],
+      process: function(block) {
+        return panel(this.output.name, block, "success", "square-o", true);
+      }
+    },
     solution: {
       process: function(block) {
         return panel(this.output.name, block, "danger", "check-square-o", true);


### PR DESCRIPTION
Adds the a new block type (`hiddenchallenge`) that is identical to challenge but hidden by default.

Requested by @VanyaBelyaev.